### PR TITLE
[Server] notice scrap 추가, 삭제 구현

### DIFF
--- a/src/notice/notice.controller.ts
+++ b/src/notice/notice.controller.ts
@@ -1,8 +1,10 @@
 import {
   Controller,
+  Delete,
   Get,
   Param,
   ParseBoolPipe,
+  Post,
   Query,
   Req,
   UseGuards,
@@ -118,5 +120,21 @@ export class NoticeController {
   @Get(':id')
   getNotice(@Req() req: UserRequest, @Param('id') id: number): Promise<Notice> {
     return this.noticeService.getNotice(req, id);
+  }
+
+  @Post(':id/scrap')
+  createScrap(
+    @Req() req: UserRequest,
+    @Param('id') id: number,
+  ): Promise<Notice> {
+    return this.noticeService.createScrap(req, id);
+  }
+
+  @Delete(':id/scrap')
+  deleteScrap(
+    @Req() req: UserRequest,
+    @Param('id') id: number,
+  ): Promise<Notice> {
+    return this.noticeService.deleteScrap(req, id);
   }
 }

--- a/src/types/custom-type.ts
+++ b/src/types/custom-type.ts
@@ -2,6 +2,7 @@ import { Request } from 'express';
 import { User } from '../user/user.entity';
 import { Department, Tag, UserTag } from '../department/department.entity';
 import { NoticePaginationDto } from 'src/notice/dto/noticePagination.dto';
+import { Notice, UserNotice } from '../notice/notice.entity';
 
 export class Payload {
   username!: string;
@@ -23,4 +24,10 @@ export interface PreQuery {
   query: NoticePaginationDto;
   user: User;
   departmentId?: number;
+}
+
+export interface PreNotice {
+  user: User;
+  notice: Notice;
+  userNotice?: UserNotice;
 }


### PR DESCRIPTION
resolve #24 

스크랩 추가, 삭제 로직을 구현하였습니다.

고민하였던 부분은 삭제 시에 userNotice instance를 지우는 방식으로 갈지 isScrapped=false로 두는 방식으로 할지를 고민하였으나, 후에 커뮤니티 기능을 추가할 때, userNotice instance에 scrap이상의 정보를 담을 수 있다는 생각이 들어서 isScrapped=false로 하는 방향으로 결정하였습니다.

추가적으로 delete에서 no contetn를 리턴하게 될 때, Nest에서 response status code를 바꾸는 것이 쉽지 않아 임시로 HttpException을 활용하여 구현하였습니다. 이 경우의 문제점은 No Content인 204가 에러 코드가 아니다 보니 response body가 나오지 않는 문제가 있고, 에러 처리를 하지 않으려고 204를 쓰는 것인데, HttpException을 쓰게 되면 그것이 의미가 없어지는 느낌이 있습니다. 공식 문서에서는 status Code를 바꾸고자 하는 경우 res를 이용하라고 되어있지만, res 를 쓰는 경우 호환성 문제나, 성능면에서 불이익이 있다는 내용 또한 있어서 우선적으로는 이렇게 구현을 해놓고, interceptor로 가능하다는 글을 본 것 같아 이 방법이 가능하다면 이 방법으로 고치도록 하겠습니다.