### PR TITLE
[Server] college column추가, tag sort 로직

### DIFF
--- a/src/department/department.entity.ts
+++ b/src/department/department.entity.ts
@@ -18,6 +18,9 @@ export class Department extends BaseEntity {
   @Column()
   name!: string;
 
+  @Column()
+  college!: string;
+
   @OneToMany(() => Notice, (notice) => notice.department)
   notices!: Notice[];
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import {
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await initializeTestDB();
+  //await initializeTestDB();
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,

--- a/src/notice/notice.entity.ts
+++ b/src/notice/notice.entity.ts
@@ -72,7 +72,11 @@ export class Notice extends BaseEntity {
   @Expose()
   get tags(): string[] {
     return this.noticeTags
-      ? this.noticeTags.map((noticeTag) => noticeTag.tag.name)
+      ? this.noticeTags
+          .sort((lhs, rhs) => {
+            return lhs.tag.id - rhs.tag.id;
+          })
+          .map((noticeTag) => noticeTag.tag.name)
       : [];
   }
 


### PR DESCRIPTION
resolve #31 

department에 college column을 추가하였습니다. 지금까지 추가되어있는 과들은 제가 쿼리를 날려 추가하고, 나머지는 크롤러를 이용해 추가하도록 하겠습니다

tag가 id ASC로 되도록 구현하였습니다. querybuilder을 이용해서 하려고 했으나, https://github.com/typeorm/typeorm/issues/4015 에서나 
https://github.com/typeorm/typeorm/issues/6767 에서 subquery를 쓰려고 했을때의 문제가 많고, 태그의 개수가 많지 않다고 생각되어 sort함수를 이용하여 구현하였습니다.