### PR TITLE
resolve slow query

### DIFF
--- a/src/department/department.entity.ts
+++ b/src/department/department.entity.ts
@@ -5,6 +5,7 @@ import {
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
+  RelationId,
 } from 'typeorm';
 import { User } from '../user/user.entity';
 import { Notice } from '../notice/notice.entity';
@@ -86,4 +87,7 @@ export class NoticeTag extends BaseEntity {
     onDelete: 'CASCADE',
   })
   tag!: Tag;
+
+  @RelationId((noticeTag: NoticeTag) => noticeTag.notice)
+  noticeId!: number;
 }


### PR DESCRIPTION
resolve #33 나머지 inner join에서는 크게 성능의 하락이 없었는데, 

tag를 받아올 때 부하가 심하게 걸려서 상규님이 말씀하셨던 방향에서 tags만 나중에 fetch해서 넣는 방향으로 하였습니다. notice의 endpoint가 200ms정도에 response를 주는 것을 확인하였습니다.