### PR TITLE
마이그레이션 로직 추가 + link indexing 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "supertest": "^6.0.0",
         "ts-jest": "^26.4.3",
         "ts-loader": "^8.0.8",
-        "ts-node": "^9.0.0",
+        "ts-node": "^9.1.1",
         "tsconfig-paths": "^3.9.0",
         "typescript": "^4.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm": "node --require ./node_modules/ts-node/register ./node_modules/typeorm/cli.js --config dist/ormconfig.js"
   },
   "dependencies": {
     "@nestjs/common": "^7.5.1",
@@ -67,7 +68,7 @@
     "supertest": "^6.0.0",
     "ts-jest": "^26.4.3",
     "ts-loader": "^8.0.8",
-    "ts-node": "^9.0.0",
+    "ts-node": "^9.1.1",
     "tsconfig-paths": "^3.9.0",
     "typescript": "^4.1.3"
   },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,16 +5,9 @@ import { UserModule } from './user/user.module';
 import { DepartmentModule } from './department/department.module';
 import { NoticeModule } from './notice/notice.module';
 import { AuthModule } from './auth/auth.module';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Keyword, User, UserKeyword } from './user/user.entity';
-import { UserNotice, File, Notice } from './notice/notice.entity';
-import {
-  Department,
-  NoticeTag,
-  Tag,
-  UserTag,
-} from './department/department.entity';
+import * as ormConfig from './ormconfig';
 
 const ENV: string | undefined = process.env.NODE_ENV;
 
@@ -24,28 +17,7 @@ const ENV: string | undefined = process.env.NODE_ENV;
       isGlobal: true,
       envFilePath: [ENV === 'production' ? '.env.prod' : '.env.dev', '.env.ci'],
     }),
-    TypeOrmModule.forRoot({
-      type: 'mariadb',
-      host: process.env.DATABASE_HOST,
-      port: +(process.env.DATABASE_PORT ?? 3306),
-      username: process.env.DATABASE_USER,
-      password: process.env.DATABASE_PASSWORD,
-      database: process.env.DATABASE_DBNAME,
-      entities: [
-        User,
-        Keyword,
-        UserNotice,
-        File,
-        Notice,
-        UserTag,
-        Tag,
-        Department,
-        NoticeTag,
-        UserKeyword,
-      ],
-      //need to be set false when production
-      synchronize: true,
-    }),
+    TypeOrmModule.forRoot(ormConfig),
     UserModule,
     DepartmentModule,
     NoticeModule,

--- a/src/migration/1620136253006-add_link_index.ts
+++ b/src/migration/1620136253006-add_link_index.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class addLinkIndex1620136253006 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'alter table notice add index `notice_link_idx` (link(255))',
+    );
+    await queryRunner.query(
+      'alter table file add index `file_link_idx` (link(255))',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('alter table notice drop index `notice_link_idx`');
+    await queryRunner.query('alter table file drop index `file_link_idx`');
+  }
+}

--- a/src/notice/notice.entity.ts
+++ b/src/notice/notice.entity.ts
@@ -40,6 +40,7 @@ export class Notice extends BaseEntity {
   @Column({ default: false })
   isPinned!: boolean;
 
+  // Index link(255) applied by migration
   @Column({ length: 1000 })
   link!: string;
 
@@ -93,6 +94,7 @@ export class File extends BaseEntity {
   @Column()
   name!: string;
 
+  // Index link(255) applied by migration
   @Column({ length: 1000 })
   link!: string;
 

--- a/src/ormconfig.ts
+++ b/src/ormconfig.ts
@@ -1,0 +1,53 @@
+import { config } from 'dotenv';
+import { ConnectionOptions } from 'typeorm';
+import * as path from 'path';
+import { Keyword, User, UserKeyword } from './user/user.entity';
+import { Notice, UserNotice, File } from './notice/notice.entity';
+import {
+  Department,
+  NoticeTag,
+  Tag,
+  UserTag,
+} from './department/department.entity';
+
+const ENV: string = process.env.NODE_ENV ?? 'dev';
+let envFile: string;
+if (ENV === 'production') {
+  envFile = '.env.prod';
+} else if (ENV === 'ci') {
+  envFile = '.env.ci';
+} else {
+  envFile = '.env.dev';
+}
+
+config({ path: path.resolve(process.cwd(), envFile) });
+
+const ormConfig: ConnectionOptions = {
+  type: 'mariadb',
+  host: process.env.DATABASE_HOST,
+  port: +(process.env.DATABASE_PORT ?? 3306),
+  username: process.env.DATABASE_USER,
+  password: process.env.DATABASE_PASSWORD,
+  database: process.env.DATABASE_DBNAME,
+  entities: [
+    User,
+    Keyword,
+    UserNotice,
+    File,
+    Notice,
+    UserTag,
+    Tag,
+    Department,
+    NoticeTag,
+    UserKeyword,
+  ],
+  //need to be set false when production
+  synchronize: false,
+  migrations: ['dist/migration/*.js'],
+  migrationsRun: true,
+  cli: {
+    migrationsDir: 'src/migration',
+  },
+};
+
+export = ormConfig;


### PR DESCRIPTION
resolve #51 
resolve #37 

Notice와 File의 link column에 index를 걸었습니다.

기존에 index를 추가하던 데코레이터를 이용한 방식을 사용하고자 하였으나,
너무 길어서 index가 추가되지 않았습니다. typeorm에도 관련 기능이 없는 듯 합니다 ([관련 링크](https://github.com/typeorm/typeorm/issues/749))

그래서 db query를 이용하여 alter table을 하고자 migration을 통해 테이블을 수정하도록 하였습니다. + 마이그레이션 이야기가 이전에도 나왔어서 겸사겸사. 처음 255자에만 index가 걸리도록 하였습니다. (지금 waffle db에 있는 것 중 가장 긴 link는 512자입니다. 추후 더 길어질 수 있을 것 같아 link max length는 건드리지 않았습니다)

synchronize를 false로 하였기 때문에, 앞으로의 db수정은 migration을 통해 진행되어야 합니다.
npm install(혹은 npm ci) 후, npm run typeorm migrate:create -- -n {name}으로 만들 수 있습니다. 그 후 작성방법은 [이 글](https://velog.io/@heumheum2/typeORM-Migration-%EC%9D%B4%EC%8A%88)이나 [typeorm](https://typeorm.io/#/migrations) 참고하시면 될 것 같습니다.

현재는 migrationRun:true인 상황이기 때문에 기존에 synchronize:true인 것처럼 서버를 실행하면 자동으로 반영되게 됩니다. 이 부분은 이미 migration으로 관리해서 저희가 컨트롤할 수 있다고 생각하기 때문에 true남겨 두었는데, 혹시 우려하시는 부분이 있다면 말씀해주시면 좋겠습니다.





