### PR TITLE
Change search logic

### DIFF
--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -153,7 +153,6 @@ export class NoticeService {
     }
     noticeQb
       .innerJoinAndSelect('notice.department', 'department')
-      .leftJoinAndSelect('notice.files', 'files')
       .orderBy('notice.createdAt', 'DESC')
       .addOrderBy('notice.id', 'DESC')
       .take(limit + 1);


### PR DESCRIPTION
resolve #35 

- 검색로직을 and로 수정합니다.

Full-Text Search를 로컬에서 실험해봤습니다. 전체 DB에서 검색하는 경우에는 like쿼리를 쓰는 것보다 훨씬 빠르지만 (900~1500ms vs 80ms) 학과별 검색에서는 큰 차이가 없는 것으로 보입니다.(150ms vs 50ms)  -  전체 notice 69000 개, 한 학과 notice: 6000개

Full text search를 도입하기 위한 비용 (추가 용량, insert속도 저하, DB설정 변경 등)이 있기때문에 지금은 가능한 옵션 중 하나 정도로 생각하다가 나중에 성능이 더 필요해지면 고려해도 될 것 같습니다. 