### PR TITLE
get departments query improved + change get tags by name to id

### DIFF
--- a/src/department/department.entity.ts
+++ b/src/department/department.entity.ts
@@ -2,6 +2,7 @@ import {
   BaseEntity,
   Column,
   Entity,
+  Index,
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -29,7 +30,8 @@ export class Department extends BaseEntity {
   @OneToMany(() => Tag, (tag) => tag.department)
   tags!: Tag[];
 
-  follow?: string[];
+  @Transform((tags) => tags.value.map((tag: Tag) => tag.name))
+  follow?: Tag[];
 }
 
 @Entity()

--- a/src/ormconfig.ts
+++ b/src/ormconfig.ts
@@ -44,7 +44,7 @@ const ormConfig: ConnectionOptions = {
   //need to be set false when production
   synchronize: false,
   migrations: ['dist/migration/*.js'],
-  migrationsRun: false,
+  migrationsRun: true,
   cli: {
     migrationsDir: 'src/migration',
   },

--- a/src/ormconfig.ts
+++ b/src/ormconfig.ts
@@ -44,7 +44,7 @@ const ormConfig: ConnectionOptions = {
   //need to be set false when production
   synchronize: false,
   migrations: ['dist/migration/*.js'],
-  migrationsRun: true,
+  migrationsRun: false,
   cli: {
     migrationsDir: 'src/migration',
   },

--- a/src/types/custom-type.ts
+++ b/src/types/custom-type.ts
@@ -31,3 +31,8 @@ export interface PreNotice {
   notice: Notice;
   userNotice?: UserNotice;
 }
+
+export interface UserDepartment {
+  user: User;
+  department?: Department;
+}


### PR DESCRIPTION
get departments의 쿼리에서 

department하나당 쿼리 한개를 추가적으로 호출하는 N+1가 발생해서 이 부분의 쿼리를 수정하였습니다

query param으로 tag를 주는 endpoint에서 name을 기반으로 찾으면 너무 느려서(index를 추가해도 처음 몇번은 느리게 나와서)
name을 기반으로 tag를 먼저 찾고, 그것의 id를 이용해 매칭하도록 하였습니다.

나머지 부분에서의 쿼리는 (IN -> Inner Join)의 경우, [이 글](https://jojoldu.tistory.com/565?category=761883)이나 [이 글2](https://jojoldu.tistory.com/520)참고해서 바꾸었는데, 큰 차이는 없는 것으로 보였습니다. NoticeTag를 먼저 뽑고 그걸 IN의 parameter로도 줬었는데, 이 방법도 크게 차이가 없습니다.