### PR TITLE
createdAt 값에 크롤링한 시점의 timestamp 값이 들어가지 않도록 수정

### DIFF
--- a/src/migration/1626177689912-set_default_timestamp.ts
+++ b/src/migration/1626177689912-set_default_timestamp.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class setDefaultTimestamp1626177689912 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      "alter table notice modify createdAt timestamp  not null default '1970-01-01 09:00:01'",
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'alter table notice modify createdAt timestamp  not null default current_timestamp on update current_timestamp',
+    );
+  }
+}


### PR DESCRIPTION
resolve #65 

서버 DB의 createdAt 칼럼이 on update current_timestamp 설정이 되어있습니다. 
mariaDB에서는 테이블의 첫번째 timestamp는 기본적으로 [작성 or 수정시간을 저장하게 되어있습니다.](https://mariadb.com/kb/en/timestamp/)

로컬 DB에서 실험했을 때 on update 설정이 없을 때에는 문제없이 실행되었고 on update current_timestamp를 설정했을 때는 일부 공지사항에 크롤링된 시간이 저장되는 것을 확인했습니다.

공지사항 update가 발생하는 경우를 완벽히 동일하게 재현하지는 못했지만 (크롤러 실행 -> npm run clean -> 다시 크롤러 실행하는 방법으로 실험, 서버에서처럼 많은 공지사항의 createdAt이 잘못되지는 않음) on update가 원인이 맞는 것 같습니다.

![https://user-images.githubusercontent.com/25146797/125438454-1d192f16-c1d9-4a35-a596-2d72f6e843f7.png](https://user-images.githubusercontent.com/25146797/125438454-1d192f16-c1d9-4a35-a596-2d72f6e843f7.png)
<서버의 DB에서`DESC snuboard.notice;`를 실행한 결과>

링크 내용을 참고하여 createdAt 칼럼의 default값을 지정해주는 방식으로 해결하려고 합니다.
