### PR TITLE
학과 reponse에서 중복된 태그 지우기

### DIFF
--- a/src/department/department.entity.ts
+++ b/src/department/department.entity.ts
@@ -26,7 +26,7 @@ export class Department extends BaseEntity {
   @OneToMany(() => Notice, (notice) => notice.department)
   notices!: Notice[];
 
-  @Transform((tags) => tags.value.map((tag: Tag) => tag.name))
+  @Transform((tags) => [...new Set(tags.value.map((tag: Tag) => tag.name))])
   @OneToMany(() => Tag, (tag) => tag.department)
   tags!: Tag[];
 


### PR DESCRIPTION
resolve #68 
department response에서 중복된 태그를 제거하여 전달합니다.

태그가 산발적으로 되어있는 과들이 많아 태그 추리는 과정이 필요해 보입니다