### PR TITLE
Full Text Search 구현하기

### DIFF
--- a/src/migration/1626523938289-add_full_text_index.ts
+++ b/src/migration/1626523938289-add_full_text_index.ts
@@ -3,7 +3,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 export class addFullTextIndex1626523938289 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      'alter table notice add fulltext (contentText, title) with parser ngram;',
+      'alter table notice add fulltext (contentText, title);',
     );
   }
 

--- a/src/migration/1626523938289-add_full_text_index.ts
+++ b/src/migration/1626523938289-add_full_text_index.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class addFullTextIndex1626523938289 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'alter table notice add fulltext (contentText, title) with parser ngram;',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('alter table notice drop INDEX contentText;');
+  }
+}

--- a/src/notice/dto/searchNoticeInDept.dto.ts
+++ b/src/notice/dto/searchNoticeInDept.dto.ts
@@ -7,14 +7,6 @@ export class SearchNoticeInDeptDto extends NoticePaginationDto {
 
   @IsBoolean()
   @IsOptional()
-  title: boolean = false;
-
-  @IsBoolean()
-  @IsOptional()
-  content: boolean = false;
-
-  @IsBoolean()
-  @IsOptional()
   pinned: boolean = false;
 
   @IsString()

--- a/src/notice/notice.controller.ts
+++ b/src/notice/notice.controller.ts
@@ -35,8 +35,6 @@ export class NoticeSummaryController {
   searchNoticeInDepartment(
     @Param('departmentId') departmentId: number,
     @Query('pinned', ParseBoolPipe) pinned: boolean,
-    @Query('title', ParseBoolPipe) title: boolean,
-    @Query('content', ParseBoolPipe) content: boolean,
     @Query() rawQuery: string,
     @Req() req: UserRequest,
   ): Promise<NoticesResponseDto> {
@@ -48,8 +46,6 @@ export class NoticeSummaryController {
       },
     );
     query.pinned = pinned;
-    query.title = title;
-    query.content = content;
 
     return this.noticeService.getNoticeInDepartment(req, departmentId, query);
   }

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -127,16 +127,9 @@ export class NoticeService {
     query: SearchFollowedNoticeDto | SearchNoticeInDeptDto,
     tags: number[],
   ): Promise<NoticesResponseDto> {
-    const selectedColumn: string =
-      query.content && query.title
-        ? 'CONCAT(notice.title, notice.contentText)'
-        : query.title
-        ? 'notice.title'
-        : 'notice.contentText';
-
     const keywords: string[] = this.splitParam(query.keywords, ' ');
     this.appendTagQb(noticeQb, tags);
-    this.appendKeywordQb(noticeQb, keywords, selectedColumn);
+    this.appendKeywordQb(noticeQb, keywords);
     return await this.makeResponse(noticeQb, user, query.limit, query.cursor);
   }
 
@@ -228,9 +221,14 @@ export class NoticeService {
       if (query.keywords.length == 0) {
         throw new BadRequestException("'keywords' should not be empty");
       }
-      if (!(query.title || query.content)) {
+      const minLength = Math.min(
+        ...this.splitParam(query.keywords, ' ').map(
+          (keyword) => keyword.length,
+        ),
+      );
+      if (minLength < 2) {
         throw new BadRequestException(
-          "At least one of 'title' and 'content' should be true",
+          'keyword should have at least 2 characters',
         );
       }
     }
@@ -264,13 +262,15 @@ export class NoticeService {
   appendKeywordQb(
     noticeQb: SelectQueryBuilder<Notice>,
     keywords: string[],
-    selectedColumn: string,
   ): void {
-    keywords.forEach((keyword, index) => {
-      noticeQb
-        .andWhere(selectedColumn + ` like :keyword${index}`)
-        .setParameter(`keyword${index}`, `%${keyword}%`);
-    });
+    const keywordParam = keywords
+      .map((keyword) => '+' + keyword)
+      .reduce((a, b) => a + ' ' + b);
+    noticeQb
+      .andWhere(
+        `match (contentText, title) against (:keywordParam IN BOOLEAN MODE)`,
+      )
+      .setParameter(`keywordParam`, keywordParam);
   }
 
   async appendTagQb(
@@ -350,11 +350,7 @@ export class NoticeService {
   ): query is SearchNoticeInDeptDto | SearchFollowedNoticeDto {
     return (
       (<SearchNoticeInDeptDto | SearchFollowedNoticeDto>query).keywords !==
-        undefined &&
-      (<SearchNoticeInDeptDto | SearchFollowedNoticeDto>query).content !==
-        undefined &&
-      (<SearchNoticeInDeptDto | SearchFollowedNoticeDto>query).title !==
-        undefined
+      undefined
     );
   }
 

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -264,7 +264,7 @@ export class NoticeService {
     keywords: string[],
   ): void {
     const keywordParam = keywords
-      .map((keyword) => '+' + keyword)
+      .map((keyword) => '+' + keyword + '*')
       .reduce((a, b) => a + ' ' + b);
     noticeQb
       .andWhere(

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -30,7 +30,6 @@ import { validate } from 'class-validator';
 import { exceptionFormatter } from '../functions/custom-function';
 
 const emptyResponse: NoticesResponseDto = { notices: [], next_cursor: '' };
-
 @Injectable()
 export class NoticeService {
   async getNotice(req: UserRequest, id: number): Promise<Notice> {
@@ -264,7 +263,7 @@ export class NoticeService {
     keywords: string[],
   ): void {
     const keywordParam = keywords
-      .map((keyword) => '+' + keyword + '*')
+      .map((keyword) => '+' + keyword.replace(/[-*+~()<>"]+/g, '') + '*')
       .reduce((a, b) => a + ' ' + b);
     noticeQb
       .andWhere(

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist","utils", "**/*spec.ts"]
 }

--- a/utils/benchmark.ts
+++ b/utils/benchmark.ts
@@ -1,0 +1,100 @@
+import { createConnection, Connection, getConnection } from 'typeorm';
+import { Notice } from '../src/notice/notice.entity';
+import { Department } from '../src/department/department.entity';
+
+import * as ormConfig from '../src/ormconfig';
+
+async function search(
+  keyword: string,
+  departments: number[],
+  searchType: string,
+) {
+  let noticeNum = 0;
+  const startTime = Date.now();
+  for (let i = 0; i < departments.length; i++) {
+    const noticeQb = getConnection()
+      .getRepository(Notice)
+      .createQueryBuilder('notice')
+      .where('departmentId = :dId', { dId: departments[i] });
+    if (searchType == 'LIKE') {
+      noticeQb.andWhere('(contentText like :keyword or title like :keyword)', {
+        keyword: `%${keyword}%`,
+      });
+    } else {
+      noticeQb.andWhere(
+        'match(contentText, title) against (+:keyword IN BOOLEAN MODE)',
+        {
+          keyword: keyword,
+        },
+      );
+    }
+    const notices = await noticeQb.limit(10).getMany();
+    noticeNum += notices.length;
+  }
+  const endTime = Date.now();
+  return { elapsedTime: endTime - startTime, noticeNum: noticeNum };
+}
+
+async function runBenchmark() {
+  const connection: Connection = await createConnection(ormConfig);
+  const departments = await getConnection()
+    .getRepository(Notice)
+    .createQueryBuilder('notice')
+    .select('notice.departmentId, count(notice.id) as noticeCount, d.name')
+    .innerJoin(Department, 'd', 'd.id = notice.departmentId')
+    .groupBy('notice.departmentId')
+    .orderBy('noticeCount', 'DESC')
+    .getRawMany();
+  const top10 = departments.slice(0, 10);
+
+  console.log('department name: number of notices');
+  top10.forEach((d) => {
+    console.log(`${d.name.padEnd(15 - d.name.length)}: ${d.noticeCount}`);
+  });
+
+  const departmentIds = top10.map((d) => d.departmentId);
+  const keywords = [
+    'cse',
+    '장학',
+    'cbe',
+    'zxcv',
+    '화요일',
+    '복수전공',
+    'data',
+    '졸업요건',
+    '부전공',
+    '비대면',
+    '학사',
+  ];
+
+  for (let i = 0; i < keywords.length; i++) {
+    const resultLike = [];
+    const resultFTS = [];
+    for (let j = 0; j < 5; j++) {
+      resultLike.push(await search(keywords[i], departmentIds, 'LIKE'));
+      resultFTS.push(await search(keywords[i], departmentIds, 'FTS'));
+    }
+    const sumLike = resultLike
+      .map((r) => r.elapsedTime)
+      .reduce((a, b) => a + b);
+    const sumFTS = resultFTS.map((r) => r.elapsedTime).reduce((a, b) => a + b);
+    console.log(``);
+    console.log(`keyword: ${keywords[i]}`);
+    console.log(
+      `elapsed time - like: ${(sumLike / resultLike.length).toFixed(2)}ms`,
+    );
+    console.log(`num of notices - like: ${resultLike[0].noticeNum}`);
+
+    //console.log(resultLike);
+    console.log(
+      `elapsed time - FTS: ${(sumFTS / resultFTS.length).toFixed(2)}ms`,
+    );
+    console.log(`num of notices - FTS: ${resultFTS[0].noticeNum}`);
+
+    //console.log(resultFTS);
+    console.log(`elapsed time ratio LIKE/FTS ${(sumLike / sumFTS).toFixed(2)}`);
+  }
+  await connection.close();
+}
+
+runBenchmark();

--- a/utils/tsconfig.json
+++ b/utils/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "../dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "strict": true
+  },
+  "files": [
+    "benchmark.ts"
+  ]
+}


### PR DESCRIPTION
resolve #64 

contentText와 title에 full text index를 생성하고 notice service의 로직을 변경합니다.
식샤 DB를 재시작한 뒤에 머지하면 될 것 같습니다. 

변경된 로직에서는 기존 API에 있었던 content, title 선택이 사라지고 검색어의 최소 길이(2글자)가 추가됩니다. 

~like로 검색한 결과와 비슷한 검색결과를 얻는 방식으로 구현했습니다~
- ~단순하게 ngram parser를 사용해서 파싱했습니다 (형태소 분석X)~
  _**mariadb가 ngram parser를 지원하지 않아 ngram parsing을 하지 않고 인덱스를 생성합니다.**_ 
  like로 검색하는 것보다 적은 수의 공지사항을 검색합니다.
  검색 키워드 뒤에 글자가 추가되는 경우는 잘 찾아내지만 키워드 앞에 글자가 추가되는 경우는 찾지 못합니다. 
  예시) 키워드가 '모집'인 경우 '모집인원' 은 찾을 수 있지만 '후기모집'은 찾지 못합니다.
  
  최소 파싱단위를 2글자로 하기 위해 innodb_ft_min_token_size=2를 설정합니다.
  검색어 최소 길이 2글자도 이 설정 때문입니다.  
  min_token_size의 기본값은 4이기 때문에 설정을 변경하지 않으면 검색어의 최소길이는 4글자가 됩니다.  

- stopword를 비활성화하였습니다.
  [예시](https://gongzza.github.io/database/mysql-fulltext-search/) stopword를 사용하는 경우 data 같은 검색어는 (아마도 stopword인 at을 포함하고 있어서) 검색이 되지 않는 것 같습니다. 

간단한 성능비교 툴을 추가했습니다. 

utils에서 tsc로 컴파일 후 snuboard-server디렉토리에서 `node dist/uitls/benchmark.js` 로 실행할 수 있습니다.

각 키워드를 공지사항이 많은 학과 10개에서 LIKE와 FTS로 검색한 뒤 실행시간과 검색된 공지사항 수를 비교합니다. 


--실행방법--
my.cnf에 
innodb_ft_min_token_size=2
innodb_ft_enable_stopword=OFF 추가 

db재시작
npm run build 
db migration

utils/  tsc
node dist/uitls/benchmark.js